### PR TITLE
Extended Messages, Various Bug Fixes

### DIFF
--- a/extmessage.py
+++ b/extmessage.py
@@ -5,10 +5,10 @@ from typing import Any,List,Dict,Tuple
 
 class ExtMessage():
     # This is the string to use to make a seemingly blank message
-    __BLANK_STR__ = '_ _'
+    BLANK_STR = '_ _'
 
     # This is the maximum length of a Discord Message
-    __MAX_CHAR_LEN__ = 2000
+    MAX_MSG_LEN = 2000
 
     def __init__(self, msgCnt:int=4, msgRsv:int=2, msg:str=''):
         self.msg    = msg
@@ -17,7 +17,7 @@ class ExtMessage():
         # See how many messages are required
         # We take the larger of the requested count or the message plus the reserved amount (to account)
         # for growth
-        reqMessages = math.ceil(len(self.msg) / self.__MAX_CHAR_LEN__)
+        reqMessages = math.ceil(len(self.msg) / self.MAX_MSG_LEN)
 
         if ((reqMessages + msgRsv) > msgCnt):
             self.msgCnt = reqMessages + msgRsv
@@ -31,14 +31,14 @@ class ExtMessage():
     def splitMessageLine(self, msg:str, length:int=None) -> List[str]:
         # Set the split length to the message default unless it has been specified
         if length is None:
-            length = self.__MAX_CHAR_LEN__
+            length = self.MAX_MSG_LEN
 
         splitMsg = []
         newStr = ''
 
         # Break the line here is it would run over the limit
         for w in msg.split():
-            if ((len(newStr) + len(w) + 1) > self.__MAX_CHAR_LEN__):
+            if ((len(newStr) + len(w) + 1) > self.MAX_MSG_LEN):
                 splitMsg.append(newStr)
                 newStr = ''
 
@@ -61,7 +61,7 @@ class ExtMessage():
         # If the line is too long, we break it up to the limits
         newMsgSplitByLine = []
         for m in msgSplitByLine:
-            if (len(m) > self.__MAX_CHAR_LEN__):
+            if (len(m) > self.MAX_MSG_LEN):
                 newMsgSplitByLine.extend(self.splitMessageLine(m))
             else:
                 newMsgSplitByLine.append(m)
@@ -71,7 +71,7 @@ class ExtMessage():
         i = 0
         for m in newMsgSplitByLine:
             # Check if we have room in this message, or need to move onto the next message
-            if (len(splitMsg[i]) + len(m) > self.__MAX_CHAR_LEN__):
+            if (len(splitMsg[i]) + len(m) > self.MAX_MSG_LEN):
                 # If this was the last message, raise an error
                 if (i+1 == self.msgCnt):
                     raise ValueError('Out of characters across all messages for message')
@@ -83,7 +83,7 @@ class ExtMessage():
         # Fill all unused messages with blank strings
         for i in range(self.msgCnt):
             if (splitMsg[i] == ''):
-                splitMsg[i] = self.__BLANK_STR__
+                splitMsg[i] = self.BLANK_STR
 
         return splitMsg 
 
@@ -101,7 +101,7 @@ class ExtMessage():
     async def edit(self, content:str):
         # Make sure the new message is not too long
         msgLen = len(content)
-        maxChars = self.msgCnt * self.__MAX_CHAR_LEN__
+        maxChars = self.msgCnt * self.MAX_MSG_LEN
         if (msgLen > maxChars):
             raise ValueError('New message of length {} is larger than max that can represented {}') 
 
@@ -133,6 +133,10 @@ class ExtMessage():
 
     async def unpin(self):
         raise NotImplementedError()
+
+    @property
+    def reactions(self):
+        return self.msgObjs[-1].reactions
 
     async def add_reaction(self, emoji):
         # Only add reactions to the last message in the chain

--- a/extmessage.py
+++ b/extmessage.py
@@ -150,7 +150,7 @@ class ExtMessage():
         # There should only be reactions on the last message in the chain
         await self.msgObjs[-1].clear_reactions()
 
-    async def clean_reactons(self):
+    async def clean_reactions(self):
         # Clears all reacts except on the last message
         for m in self.msgObjs[:-1]:
             await m.clear_reactions()

--- a/extmessage.py
+++ b/extmessage.py
@@ -1,0 +1,162 @@
+import asyncio
+import discord
+import math
+from typing import Any,List,Dict,Tuple
+
+class ExtMessage():
+    # This is the string to use to make a seemingly blank message
+    __BLANK_STR__ = '_ _'
+
+    # This is the maximum length of a Discord Message
+    __MAX_CHAR_LEN__ = 2000
+
+    def __init__(self, msgCnt:int=4, msgRsv:int=2, msg:str=''):
+        self.msg    = msg
+        self.msgObjs= []
+
+        # See how many messages are required
+        # We take the larger of the requested count or the message plus the reserved amount (to account)
+        # for growth
+        reqMessages = math.ceil(len(self.msg) / self.__MAX_CHAR_LEN__)
+
+        if ((reqMessages + msgRsv) > msgCnt):
+            self.msgCnt = reqMessages + msgRsv
+        else:
+            self.msgCnt = msgCnt
+
+        # The ID will eventually be a message ID, but since it hasn't been created yet
+        # we set it to -1 to denote that it is invalid
+        self.id = -1
+
+    def splitMessageLine(self, msg:str, length:int=None) -> List[str]:
+        # Set the split length to the message default unless it has been specified
+        if length is None:
+            length = self.__MAX_CHAR_LEN__
+
+        splitMsg = []
+        newStr = ''
+
+        # Break the line here is it would run over the limit
+        for w in msg.split():
+            if ((len(newStr) + len(w) + 1) > self.__MAX_CHAR_LEN__):
+                splitMsg.append(newStr)
+                newStr = ''
+
+            newStr += w + ' '
+        else:
+            splitMsg.append(newStr)
+
+        return splitMsg
+
+    def splitMessage(self) -> List[str]:
+        # Create blank messages based on how many messages we need to return
+        splitMsg = []
+        for _ in range(self.msgCnt):
+            splitMsg.append('')
+
+        # We first will try to split the message just by newlines and hope that this fits well
+        msgSplitByLine = self.msg.splitlines(keepends=True)
+
+        # Make sure none of the split lines are too big
+        # If the line is too long, we break it up to the limits
+        newMsgSplitByLine = []
+        for m in msgSplitByLine:
+            if (len(m) > self.__MAX_CHAR_LEN__):
+                newMsgSplitByLine.extend(self.splitMessageLine(m))
+            else:
+                newMsgSplitByLine.append(m)
+
+        # Allocate lines to the messages. Be greedy and try to fill from the top rather than
+        # evenly across them
+        i = 0
+        for m in newMsgSplitByLine:
+            # Check if we have room in this message, or need to move onto the next message
+            if (len(splitMsg[i]) + len(m) > self.__MAX_CHAR_LEN__):
+                # If this was the last message, raise an error
+                if (i+1 == self.msgCnt):
+                    raise ValueError('Out of characters across all messages for message')
+                else:
+                    i+=1
+
+            splitMsg[i] += m
+
+        # Fill all unused messages with blank strings
+        for i in range(self.msgCnt):
+            if (splitMsg[i] == ''):
+                splitMsg[i] = self.__BLANK_STR__
+
+        return splitMsg 
+
+    async def create(self, channel):
+        # Get all the messages we need
+        messages = self.splitMessage()
+
+        # Create the number of messages needed and store their objects
+        for i in range(self.msgCnt):
+            self.msgObjs.append(await channel.send(messages[i]))
+
+        # The last object's ID is our ID
+        self.id = self.msgObjs[-1].id
+    
+    async def edit(self, content:str):
+        # Make sure the new message is not too long
+        msgLen = len(content)
+        maxChars = self.msgCnt * self.__MAX_CHAR_LEN__
+        if (msgLen > maxChars):
+            raise ValueError('New message of length {} is larger than max that can represented {}') 
+
+        # Store the message, then reparse to prepare for editing
+        self.msg = content
+        messages = self.splitMessage()
+
+        # Edit each message
+        # We compare the contents to the new strings and only edit if they differ. This is less for performance
+        # than to try to save the "edited" tag on the blank messages
+        for i in range(self.msgCnt):
+            if (self.msgObjs[i].content != messages[i]):
+                await self.msgObjs[i].edit(content=messages[i])
+
+    async def delete(self, delay=None):
+        # Delete each message
+        for i in range(self.msgCnt):
+            await self.msgObjs[i].delete(delay=delay)
+
+        # Clear variables and IDs in case this object gets reused
+        self.msgObjs = []
+        self.id = -1
+
+    async def publish(self):
+        raise NotImplementedError()
+
+    async def pin(self):
+        raise NotImplementedError()
+
+    async def unpin(self):
+        raise NotImplementedError()
+
+    async def add_reaction(self, emoji):
+        # Only add reactions to the last message in the chain
+        await self.msgObjs[-1].add_reaction(emoji)
+
+    async def remove_reaction(self, emoji):
+        # There should only be reactions on the last message in the chain
+        await self.msgObjs[-1].remove_reaction(emoji)
+
+    async def clear_reactions(self):
+        # There should only be reactions on the last message in the chain
+        await self.msgObjs[-1].clear_reactions()
+
+    async def clean_reactons(self):
+        # Clears all reacts except on the last message
+        for m in self.msgObjs[:-1]:
+            await m.clear_reactions()
+
+    def check_ids(self, id:int) -> bool:
+        for m in self.msgObjs:
+            if m.id == id:
+                return True
+        
+        return False
+        
+
+        

--- a/rsvp.py
+++ b/rsvp.py
@@ -8,6 +8,7 @@ import textwrap
 from typing import Any,Dict,List,Tuple
 
 # Internal Libraries
+import extmessage
 import tracker
 
 class rsvp(commands.Cog):
@@ -56,6 +57,7 @@ class rsvp(commands.Cog):
     expireTimeFmt  = '%A %b %d - %H:%M:%S %Z'
 
     # RegEx to search a message for a line starting with a discord emoji
+    # TODO: There is a bug where this will pick up reacts that aren't the first non-space in the line
     emojiRegex = re.compile(r'(<:(\w*):(\d*)>)')
 
     # Regex to search a message for a line starting with a unicode emoji
@@ -127,7 +129,7 @@ class rsvp(commands.Cog):
         await event.msgObj.edit(content = msg)
 
     '''
-    Parsers a message for emojis that are at the start of the line, indicating that they
+    Parses a message for emojis that are at the start of the line, indicating that they
     are special
     '''
     def parseMsg(self, event:tracker.Tracker):
@@ -168,7 +170,10 @@ class rsvp(commands.Cog):
 
         # We need to create a message and send it to get a messageID, since we use the messageID as the identifier
         # We will edit the actual content later
-        msg = await ctx.channel.send('Preparing an RSVP message...')
+        # We reserve for at least 4 messages since the RSVP is at most 1, overhead for header and footer are hopefully
+        # just 1, and leave 2 for signups.
+        msg = extmessage.ExtMessage(msgCnt=4, msg='Preparing an RSVP message...')
+        await msg.create(ctx.channel)
 
         # Finish setting up the RSVP Event Object
         t = self.tracker.createTrackedItem(msg, owner, msg=msgBody, cogOwner=type(self).__name__)

--- a/rsvp.py
+++ b/rsvp.py
@@ -141,7 +141,10 @@ class rsvp(commands.Cog):
             print(matchObj)
             if matchObj is not None:
                 tEmoji = discord.PartialEmoji(animated=False, name=matchObj.group(2), id=int(matchObj.group(3)))
-                trackedEmojis.append(tEmoji)
+
+                # Prevent duplicates from making it into the list
+                if tEmoji not in trackedEmojis:
+                    trackedEmojis.append(tEmoji)
                 continue
 
             # Next try to lookup the  by unicode
@@ -150,7 +153,10 @@ class rsvp(commands.Cog):
             print(matchObj)
             if matchObj is not None:
                 tEmoji = discord.PartialEmoji(animated=False, name=matchObj.group(0), id=None)
-                trackedEmojis.append(tEmoji)
+
+                # Prevent duplicates from making it into the list
+                if tEmoji not in trackedEmojis:
+                    trackedEmojis.append(tEmoji)
                 continue
 
         event.cogData = trackedEmojis

--- a/rsvp.py
+++ b/rsvp.py
@@ -210,7 +210,7 @@ class rsvp(commands.Cog):
             argSplitSpace = argSplitLine[0].split(' ')
             msgId = int(argSplitSpace[0].strip())
         except:
-            print('RSVP Edit did not get a message ID, so we cant do anything. Skipping...')
+            print('RSVP Edit did not get a message ID, so we cant do anything. Arg was: {}'.format(arg))
             await ctx.send('RSVP Edit could not parse out a message ID to edit. Please check your syntax.\n' + 
                            'It should be: edit <message ID> <new Message>')
             return
@@ -275,34 +275,39 @@ class rsvp(commands.Cog):
         if ctx.author == self.bot.user:
             return
 
-        # Delete the modifying message to indicate that we've processed it
-        await ctx.message.delete()
-
         # Attempt to coerce the arguments from a string to an int and perform a lookup for the ID
         try:
             msgId = int(arg)
         except:
-            print('Failed to convert rsvp delete argument to delete. Got {}'.format(arg))
+            print('RSVP Delete did not get a message ID, so we cant do anything. Argument was: {}'.format(arg))
+            await ctx.send('RSVP Delete could not parse out a message ID to delete. Please check your syntax.\n' + 
+                           'It should be: delete <message ID>')
             return
         else:
             event = self.tracker.getTrackedItem(msgId)
 
         # Skip modifying anything if we aren't tracking this message
         if event is None:
-            print('Could not find {:d} in the tracker so ignoring this'.format(msgId))
+            print('RSVP Delete is not tracking anything with ID {}. Skipping...'.format(msgId))
+            await ctx.send('RSVP Delete could not find a message that is active with ID {}. Double check your message ID.'.format(msgId))
             return
 
         # Only the owner is allowed to delete
         if ctx.author != event.owner:
-            print('Delete called by {} but is not the owner {}'.format(ctx.author.display_name, event.owner.display_name))
+            print('RSVP Delete was called by {}, who is not the owner ({})'.format(
+                ctx.author.display_name,
+                event.owner.display_name))
+            await ctx.send('RSVP Delete can only be used on messages you own. You are {} but the owner is {}'.format(
+                ctx.author.display_name,
+                event.owner.display_name))
             return
 
         # Delete the message
         await event.msgObj.delete()
         self.tracker.deleteTrackedItem(msgId)
 
-        # Debug
-        print(self.rsvps)
+        # Delete the modifying message to indicate that we've processed it
+        await ctx.message.delete()
 
     @rsvp.command(brief = '''Extends the duration of an existing RSVP event message.''',
                   help  = '''Extends the duration of an existing RSVP message. Only the owner of the message can
@@ -311,26 +316,26 @@ class rsvp(commands.Cog):
                            provided is the number of time units to extend by.''',
                   usage = '''<systemID> <quantity>''')
     async def extend(self, ctx, sysId, qty):
-        ## Ignore ourselves
+        # Ignore ourselves
         if ctx.author == self.bot.user:
             return
 
-        # Delete the modifying message to indicate that we've processed it
-        await ctx.message.delete()
-
-        ## Attempt to coerce the arguments from strings to ints
+        # Attempt to coerce the arguments from strings to ints
         try:
             msgId     = int(sysId)
             timeUnits = int(qty)
         except:
-            print('Failed to convert rsvp delete argument to delete. Got System ID: {}, Quantity: {}'.format(sysId, qty))
+            print('RSVP Extend Failed to convert rsvp delete argument to delete. Got System ID: {}, Quantity: {}'.format(sysId, qty))
+            await ctx.send('RSVP Extend could not parse out a message ID or time quantity to extend. Please check your syntax.\n' + 
+                           'It should be: extend <message ID> <quantity>')
             return
         else:
             event = self.tracker.getTrackedItem(msgId)
 
         # Skip modifying anything if we aren't tracking this message
         if event is None:
-            print('Could not find {:d} in the tracker so ignoring this'.format(msgId))
+            print('RSVP Extend is not tracking anything with ID {}. Skipping...'.format(msgId))
+            await ctx.send('RSVP Extend could not find a message that is active with ID {}. Double check your message ID.'.format(msgId))
             return
 
         # Extend the message
@@ -340,5 +345,5 @@ class rsvp(commands.Cog):
         # Reprint the message
         await self.msgGenerator(event)
 
-        # Debug
-        print(self.rsvps)
+        # Delete the modifying message to indicate that we've processed it
+        await ctx.message.delete()

--- a/tracker.py
+++ b/tracker.py
@@ -154,7 +154,9 @@ class reactTracker(commands.Cog):
         self.msgCb = {}
         self.procCb = {}
 
-        bot.loop.create_task(self.load_settings())
+        # Disable loading of saved reactTracker settings
+        # It's not used very often, and is currently partially broken with extended messages
+        #bot.loop.create_task(self.load_settings())
         bot.loop.create_task(self.gc_task())
 
     '''
@@ -393,10 +395,11 @@ class reactTracker(commands.Cog):
     states we may have so that coming back we will pick up right where we left off.
     '''
     def cog_unload(self):
-        try:
-            with open(self.jsonFileName, 'w+') as f:
-                json.dump(self.trackedItems, f, default=Tracker.encode, indent=4)
-        except Exception as e:
-            print('got exception')
-            print(e)
+        # Saving state is disabled. See explanation in the load_settings function
+        #try:
+        #    with open(self.jsonFileName, 'w+') as f:
+        #        json.dump(self.trackedItems, f, default=Tracker.encode, indent=4)
+        #except Exception as e:
+        #    print('got exception')
+        #    print(e)
         print('reactTracker unloading')


### PR DESCRIPTION
This fixes several outstanding bugs and feature requests.

New Features:
- Messages can now span multiple messages. This will inherently be limited by the RSVP Add limiting the number of characters for the message, but the message, overhead, and signups can now grow outside of single message.
- RSVP Edit and Delete now will provide better feedback on what went wrong when possible in the form of a message back in discord

Bug Fixes:
- Emojis are now properly only parsed if they are the first non-whitespace character in the line. They are otherwise ignored
- It was possible to use multiple of the same emojis. If a user reacted to these, the reaction list in the sign-ups section would duplicate the emoji multiple times. This is now fixed so that a repeated emoji is only counted once
- There were some bugs with RSVP Edit and taking taking the updated emojis which should now be fixed

Deprecations:
- State saving (saving the state of the tracker on shutdown and loading the state on startup) is disabled. This feature is not used often, and extended messages do not implement support for it.